### PR TITLE
Link against embedded libraries in crates

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -859,6 +859,8 @@ class Crate(object):
             cmd.append('%s' % out_dir)
             cmd.append('-L')
             cmd.append('%s' % out_dir)
+            cmd.append('-L')
+            cmd.append('%s/lib' % out_dir)
 
             for e in externs:
                 cmd.append('--extern')


### PR DESCRIPTION
Some crates (e.g., libgit2) ship embedded libraries, which get put into
lib/ under target-dir. Without this patch, linking the bootstrapped
cargo may or may not fail, depending on which versions of those
libraries are installed system-wide. On my OpenBSD -current system,
there's a version mismatch and it fails.
