### PR TITLE
Use crate name as library name if none is explicitly set

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -902,6 +902,7 @@ class Crate(object):
             cmd.append(os.path.join(self._dir, b['path']))
             cmd.append('--crate-name')
             if b['type'] == 'lib':
+                b.setdefault('name', self.name())
                 cmd.append(b['name'].replace('-','_'))
                 cmd.append('--crate-type')
                 cmd.append('lib')


### PR DESCRIPTION
Running cargo-bootstrap fails for me when it reaches the regex crate:

```
Exception:
 from ./bootstrap.py, line 913:
 'name'
```

After looking into it, it's complaining about a missing name because [the Cargo.toml for the regex crate](https://github.com/rust-lang-nursery/regex/blob/bf6bc5f47281ec66535f5d274a1ff7e3ffb706bd/Cargo.toml) does not explicitly set a name for the library:

```
[lib]
# There are no benchmarks in the library code itself
bench = false
```

According to [the Cargo docs](http://doc.crates.io/manifest.html#configuring-a-target) if a library name is not set it defaults to the name of the crate. This patch makes cargo-bootstrap observe that behaviour, and with it I can continue past this stage of the build.
