### PR TITLE
Print errors and exit when encountering Cargo.toml errors

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1210,7 +1210,7 @@ def crate_info_from_toml(cdir):
 
     except Exception, e:
         dbg('failed to load toml file for: %s (%s)' % (cdir, str(e)))
-        import pdb; pdb.set_trace()
+        sys.exit(1)
 
     return (None, None, [], 'lib.rs')
 


### PR DESCRIPTION
I encounter errors parsing Cargo.toml files quite frequently as I fiddle with this, which causes the script to go into interactive debug mode:

```
git2: Looking up info for url ^0.5.0
git2: opening crate info: /home/zofrex/crates/3/u/url
git2: best match is url-0.5.9
> /home/zofrex/cargo/bootstrap.py(1156)crate_info_from_toml()
-> dbg('failed to load toml file for: %s (%s)' % (cdir, str(e)))
(Pdb) 
```

This makes it unclear what actually went wrong, and also makes it harder to use this script in an automated manner.

With this patch in place, the above output is replaced with:

```
git2: Looking up info for url ^0.5.0
git2: opening crate info: /home/zofrex/crates/3/u/url
git2: best match is url-0.5.9
git2: failed to load toml file for: /home/zofrex/cargo-out/url-0.5.9 (/home/zofrex/cargo-out/url-0.5.9/Cargo.toml(14, 10): msg)
```

This is quite a lot more useful for debugging (although I am slightly suspicious of the "msg" in there - is that supposed to be expanded to something more helpful?)
